### PR TITLE
Save compatible version of `filenames`, `arrays` and `ccds` function

### DIFF
--- a/src/CCDReduction.jl
+++ b/src/CCDReduction.jl
@@ -23,7 +23,9 @@ export subtract_bias,
        arrays,
        filenames,
        ccds,
-       CCDData
+       CCDData,
+       data,
+       hdr
 
 include("ccddata.jl")
 include("methods.jl")

--- a/src/CCDReduction.jl
+++ b/src/CCDReduction.jl
@@ -22,7 +22,7 @@ export subtract_bias,
        fitscollection,
        arrays,
        filenames,
-       images,
+       ccds,
        CCDData
 
 include("ccddata.jl")

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -42,8 +42,8 @@ end
 
 
 """
-    writefits(file_path, data; header = nothing)
-    writefits(file_path, ccd::CCDData)
+    CCDReduction.writefits(file_path, data; header = nothing)
+    CCDReduction.writefits(file_path, ccd::CCDData)
 
 Writes `data`/`ccd` in FITS format at `file_path`.
 
@@ -250,7 +250,15 @@ end
 
 
 """
-    ccds(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    ccds(f,
+         collection;
+         path = nothing,
+         save_prefix = nothing,
+         save_suffix = nothing,
+         save = any(!isnothing, (save_prefix, path, save_suffix)),
+         save_delim = "_",
+         ext = r"fits(\\.tar\\.gz)?"i,
+         kwargs...)
 
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
@@ -270,7 +278,7 @@ The above generates `processed_images` which consists of trimmed versions of ima
 
 For saving the `processed_images` simultaneously with the operations performed
 ```julia
-processed_images = map(ccds(collection; save = true, path = "~/data/tekdata", save_prefix = "trimmed")) do img
+processed_images = map(ccds(collection; path = "~/data/tekdata", save_prefix = "trimmed")) do img
     trim(img, (:, 1040:1059))
 end
 ```
@@ -278,7 +286,15 @@ The trimmed images are saved as `trimmed_(original_name)` (FITS files) at `path 
 
 Mapping version of `ccds` function is interfaced on iterative version of `images`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function ccds(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function ccds(f,
+              collection;
+              path = nothing,
+              save_prefix = nothing,
+              save_suffix = nothing,
+              save = any(!isnothing, (save_prefix, path, save_suffix)),
+              save_delim = "_",
+              ext = r"fits(\.tar\.gz)?"i,
+              kwargs...)
     image_iterator = ccds(collection; kwargs...)
     locations = collection.path
 
@@ -296,7 +312,15 @@ end
 
 
 """
-    filenames(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    filenames(f,
+              collection;
+              path = nothing,
+              save_prefix = nothing,
+              save_suffix = nothing,
+              save = any(!isnothing, (save_prefix, path, save_suffix)),
+              save_delim = "_",
+              ext = r"fits(\\.tar\\.gz)?"i,
+              kwargs...)
 
 Iterates over the file paths of the collection applying function `f` at each step.
 
@@ -318,7 +342,7 @@ end
 The above generates `data` which consists of image arrays corresponding to 1st hdu of FITS file paths present in `collection`.
 For saving the `data` simultaneously with the operations performed
 ```julia
-data = map(filenames(collection; save = true, path = "~/data/tekdata", save_prefix = "retrieved_from_filename")) do img
+data = map(filenames(collection; path = "~/data/tekdata", save_prefix = "retrieved_from_filename")) do img
     fh = FITS(path)
     data = getdata(fh[1]) # assuming all 1-hdu are ImageHDUs
     close(fh)
@@ -329,7 +353,15 @@ The retrieved data is saved as `retrieved_from_filename_(original_name)` (FITS f
 
 Mapping version of `filenames` function is interfaced on iterative version of `filenames`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function filenames(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function filenames(f,
+                   collection;
+                   path = nothing,
+                   save_prefix = nothing,
+                   save_suffix = nothing,
+                   save = any(!isnothing, (save_prefix, path, save_suffix)),
+                   save_delim = "_",
+                   ext = r"fits(\.tar\.gz)?"i,
+                   kwargs...)
     path_iterator = filenames(collection; kwargs...)
     locations = collection.path
 
@@ -347,7 +379,15 @@ end
 
 
 """
-    arrays(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    arrays(f,
+           collection;
+           save = any(!isnothing, (save_prefix, path, save_suffix)),
+           path = nothing,
+           save_prefix = nothing,
+           save_suffix = nothing,
+           save_delim = "_",
+           ext = r"fits(\\.tar\\.gz)?"i,
+           kwargs...)
 
 Iterates over the image arrays of the collection applying function `f` at each step.
 
@@ -366,7 +406,7 @@ end
 The above generates `processed_images` which consists of trimmed versions of image arrays present in `collection`.
 For saving the `processed_images` simultaneously with the operations performed
 ```julia
-processed_images = map(arrays(collection; save = true, path = "~/data/tekdata", save_prefix = "trimmed")) do img
+processed_images = map(arrays(collection; path = "~/data/tekdata", save_prefix = "trimmed")) do img
     trim(img, (:, 1040:1059))
 end
 ```
@@ -374,7 +414,15 @@ The trimmed image arrays are saved as `trimmed_(original_name)` (FITS files) at 
 
 Mapping version of `arrays` function is interfaced on iterative version of `arrays`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function arrays(f, collection; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function arrays(f,
+                collection;
+                save = any(!isnothing, (save_prefix, path, save_suffix)),
+                path = nothing,
+                save_prefix = nothing,
+                save_suffix = nothing,
+                save_delim = "_",
+                ext = r"fits(\.tar\.gz)?"i,
+                kwargs...)
     array_iterator = arrays(collection; kwargs...)
     locations = collection.path
 

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -329,9 +329,7 @@ end
 Iterates over the file paths of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on file paths.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
-Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
-`ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
+The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Examples
 ```julia

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -250,7 +250,7 @@ end
 
 
 """
-    ccds(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    ccds(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
 
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
@@ -278,7 +278,7 @@ The trimmed images are saved as `trimmed_(original_name)` (FITS files) at `path 
 
 Mapping version of `ccds` function is interfaced on iterative version of `images`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function ccds(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function ccds(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
     image_iterator = ccds(collection; kwargs...)
     locations = collection.path
 
@@ -296,7 +296,7 @@ end
 
 
 """
-    filenames(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    filenames(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
 
 Iterates over the file paths of the collection applying function `f` at each step.
 
@@ -329,7 +329,7 @@ The retrieved data is saved as `retrieved_from_filename_(original_name)` (FITS f
 
 Mapping version of `filenames` function is interfaced on iterative version of `filenames`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function filenames(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function filenames(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
     path_iterator = filenames(collection; kwargs...)
     locations = collection.path
 
@@ -347,7 +347,7 @@ end
 
 
 """
-    arrays(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
+    arrays(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\\.tar\\.gz)?"i, kwargs...)
 
 Iterates over the image arrays of the collection applying function `f` at each step.
 
@@ -374,7 +374,7 @@ The trimmed image arrays are saved as `trimmed_(original_name)` (FITS files) at 
 
 Mapping version of `arrays` function is interfaced on iterative version of `arrays`, any valid parameter can be passed into iterative version as `kwargs`.
 """
-function arrays(f, collection::DataFrame; save = false, path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
+function arrays(f, collection::DataFrame; save = any(!isnothing, (save_prefix, path, save_suffix)), path = nothing, save_prefix = nothing, save_suffix = nothing, save_delim = "_", ext = r"fits(\.tar\.gz)?"i, kwargs...)
     array_iterator = arrays(collection; kwargs...)
     locations = collection.path
 

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -42,15 +42,15 @@ end
 
 
 """
-    write_data(file_path, data; header = nothing)
-    write_data(file_path, ccd::CCDData)
+    writefits(file_path, data; header = nothing)
+    writefits(file_path, ccd::CCDData)
 
 Writes `data`/`ccd` in FITS format at `file_path`.
 
 `FITSIO` takes over memory write in by `cfitsio`, which writes in row-major form, whereas when Julia gives that memory, it is assumed as column major.
 Therefore all data written by [`FITSIO.write`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#Base.write-Tuple{FITS,Dict{String,V}%20where%20V}) is transposed. This function allows the user to write the data in a consistent way to FITS file by transposing before writing.
 """
-function write_data(file_path, data; header = nothing)
+function writefits(file_path, data; header = nothing)
     d = ndims(data)
     transposed_data = permutedims(data, d:-1:1)
     FITS(file_path, "w") do fh
@@ -58,7 +58,7 @@ function write_data(file_path, data; header = nothing)
     end
 end
 
-write_data(file_path, ccd::CCDData) = write_data(file_path, ccd.data; header = ccd.hdr)
+writefits(file_path, ccd::CCDData) = writefits(file_path, ccd.data; header = ccd.hdr)
 
 #---------------------------------------------------------------------------------------
 @doc raw"""
@@ -255,7 +255,7 @@ end
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on `CCDData`s.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 
@@ -286,7 +286,7 @@ function ccds(f, collection::DataFrame; save = false, path = nothing, save_prefi
         processed_image = f(output)
         if save
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
-            write_data(save_path, processed_image)
+            writefits(save_path, processed_image)
         end
         processed_image
     end
@@ -301,7 +301,7 @@ end
 Iterates over the file paths of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on file paths.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 
@@ -337,7 +337,7 @@ function filenames(f, collection::DataFrame; save = false, path = nothing, save_
         processed_image = f(output)
         if save
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
-            write_data(save_path, processed_image)
+            writefits(save_path, processed_image)
         end
         processed_image
     end
@@ -352,7 +352,7 @@ end
 Iterates over the image arrays of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on image arrays.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 
@@ -382,7 +382,7 @@ function arrays(f, collection::DataFrame; save = false, path = nothing, save_pre
         processed_image = f(output)
         if save
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
-            write_data(save_path, processed_image)
+            writefits(save_path, processed_image)
         end
         processed_image
     end

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -59,7 +59,14 @@ end
 
 #---------------------------------------------------------------------------------------
 @doc raw"""
-    fitscollection(dir; recursive=true, abspath=true, keepext=true, ext=r"fits(\.tar\.gz)?", exclude=nothing, exclude_dir=nothing, exclude_key = ("", "HISTORY"))
+    fitscollection(dir;
+                   recursive=true,
+                   abspath=true,
+                   keepext=true,
+                   ext=r"fits(\.tar\.gz)?",
+                   exclude=nothing,
+                   exclude_dir=nothing,
+                   exclude_key=("", "HISTORY"))
 
 Walk through `dir` collecting FITS files, scanning their headers, and culminating into a `DataFrame` that can be used with the generators for iterating over many files and processing them. If `recursive` is false, no subdirectories will be walked through.
 
@@ -149,6 +156,27 @@ end
     arrays(df::DataFrame)
 
 Generator for arrays of images of entries in data frame.
+
+Iterates over `collection` using each `path` and `hdu` to load data using [`CCDReduction.getdata`](@ref) into an `Array`.
+
+# Examples
+```julia
+collection = fitscollection("~/data/tekdata")
+data = arrays(collection) |> collect
+```
+This returns all image arrays present in `collection`. This can also be used via a for-loop
+```julia
+collection = fitscollection("~/data/tekdata")
+for arr in arrays(collection)
+    @assert arr isa Array
+    println(size(arr))
+end
+
+# output
+(1048, 1068)
+(1048, 1068)
+...
+```
 """
 function arrays end
 
@@ -166,6 +194,22 @@ end
     filenames(df::DataFrame)
 
 Generator for filenames of entries in data frame.
+
+Iterates over `collection` using each `path`.
+
+# Examples
+```julia
+collection = fitscollection("~/data/tekdata")
+for path in filenames(collection)
+    @assert path isa String
+    println(path)
+end
+
+# output
+"~/data/tekdata/tek001.fits"
+"~/data/tekdata/tek002.fits"
+...
+```
 """
 function filenames end
 
@@ -181,6 +225,16 @@ end
     ccds(df::DataFrame)
 
 Generator for `CCDData`s of entries in data frame.
+
+Iterates over `collection` using each `path` and `hdu` to load data using [`FITSIO.FITS`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#FITSIO.FITS) into a [`CCDData`](@ref).
+
+# Examples
+```julia
+collection = fitscollection("~/data/tekdata")
+for hdu in ccds(collection)
+    @assert hdu isa CCDData
+end
+```
 """
 function ccds end
 

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -301,6 +301,10 @@ function ccds(f,
     processed_images = map(zip(locations, image_iterator)) do (location, output)
         processed_image = f(output)
         if save
+            # if path is nothing and still the file is being saved, the location of input file is used
+            if path isa Nothing
+                path = dirname(location)
+            end
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
             writefits(save_path, processed_image)
         end
@@ -368,6 +372,10 @@ function filenames(f,
     processed_images = map(zip(locations, path_iterator)) do (location, output)
         processed_image = f(output)
         if save
+            # if path is nothing and still the file is being saved, the location of input file is used
+            if path isa Nothing
+                path = dirname(location)
+            end
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
             writefits(save_path, processed_image)
         end
@@ -381,10 +389,10 @@ end
 """
     arrays(f,
            collection;
-           save = any(!isnothing, (save_prefix, path, save_suffix)),
            path = nothing,
            save_prefix = nothing,
            save_suffix = nothing,
+           save = any(!isnothing, (save_prefix, path, save_suffix)),
            save_delim = "_",
            ext = r"fits(\\.tar\\.gz)?"i,
            kwargs...)
@@ -416,10 +424,10 @@ Mapping version of `arrays` function is interfaced on iterative version of `arra
 """
 function arrays(f,
                 collection;
-                save = any(!isnothing, (save_prefix, path, save_suffix)),
                 path = nothing,
                 save_prefix = nothing,
                 save_suffix = nothing,
+                save = any(!isnothing, (save_prefix, path, save_suffix)),
                 save_delim = "_",
                 ext = r"fits(\.tar\.gz)?"i,
                 kwargs...)
@@ -429,6 +437,10 @@ function arrays(f,
     processed_images = map(zip(locations, array_iterator)) do (location, output)
         processed_image = f(output)
         if save
+            # if path is nothing and still the file is being saved, the location of input file is used
+            if path isa Nothing
+                path = dirname(location)
+            end
             save_path = generate_filename(location, path, save_prefix, save_suffix, save_delim, ext)
             writefits(save_path, processed_image)
         end

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -160,7 +160,7 @@ end
 
 Generator for arrays of images of entries in data frame.
 
-Iterates over `collection` using each `path` and `hdu` to load data using [`CCDReduction.getdata`](@ref) into an `Array`.
+Iterates over `collection` using each `path` and `hdu` to load data into an `Array`.
 
 # Examples
 ```julia
@@ -229,7 +229,7 @@ end
 
 Generator for `CCDData`s of entries in data frame.
 
-Iterates over `collection` using each `path` and `hdu` to load data using [`FITSIO.FITS`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#FITSIO.FITS) into a [`CCDData`](@ref).
+Iterates over `collection` using each `path` and `hdu` to load data into a [`CCDData`](@ref).
 
 # Examples
 ```julia
@@ -262,7 +262,6 @@ end
 
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
-It returns an array of output values of function `f` applied on `CCDData`s.
 The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Example
@@ -281,8 +280,6 @@ processed_images = map(ccds(collection; path = "~/data/tekdata", save_prefix = "
 end
 ```
 The trimmed images are saved as `trimmed_(original_name)` (FITS files) at `path = "~/data/tekdata"` as specified by the user.
-
-Mapping version of `ccds` function is interfaced on iterative version of `images`, any valid parameter can be passed into iterative version as `kwargs`.
 """
 function ccds(f,
               collection;
@@ -326,7 +323,6 @@ end
 
 Iterates over the file paths of the collection applying function `f` at each step.
 
-It returns an array of output values of function `f` applied on file paths.
 The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Examples
@@ -350,8 +346,6 @@ data = map(filenames(collection; path = "~/data/tekdata", save_prefix = "retriev
 end
 ```
 The retrieved data is saved as `retrieved_from_filename_(original_name)` (FITS files) at `path = "~/data/tekdata"` as specified by the user.
-
-Mapping version of `filenames` function is interfaced on iterative version of `filenames`, any valid parameter can be passed into iterative version as `kwargs`.
 """
 function filenames(f,
                    collection;
@@ -395,7 +389,6 @@ end
 
 Iterates over the image arrays of the collection applying function `f` at each step.
 
-It returns an array of output values of function `f` applied on image arrays.
 The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Examples
@@ -413,8 +406,6 @@ processed_images = map(arrays(collection; path = "~/data/tekdata", save_prefix =
 end
 ```
 The trimmed image arrays are saved as `trimmed_(original_name)` (FITS files) at `path = "~/data/tekdata"` as specified by the user.
-
-Mapping version of `arrays` function is interfaced on iterative version of `arrays`, any valid parameter can be passed into iterative version as `kwargs`.
 """
 function arrays(f,
                 collection;

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -187,8 +187,6 @@ function ccds end
 # generator for CCDData specified by data frame (i.e. path of file, hdu etc.)
 @resumable function ccds(df::DataFrame)
     for row in eachrow(df)
-        fh = FITS(row.path)
-        @yield CCDData(fh[row.hdu])
-        close(fh)
+        @yield CCDData(row.path; hdu = row.hdu)
     end
 end

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -255,7 +255,7 @@ end
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on `CCDData`s.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_fits`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 
@@ -301,7 +301,7 @@ end
 Iterates over the file paths of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on file paths.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_fits`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 
@@ -352,7 +352,7 @@ end
 Iterates over the image arrays of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on image arrays.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_fits`](@ref). File is saved at `path` specified by the user.
+In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.write_data`](@ref). File is saved at `path` specified by the user.
 Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
 `ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
 

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -130,15 +130,17 @@ end
 
 
 """
-    images(df::DataFrame)
+    ccds(df::DataFrame)
 
-Generator for `ImageHDU`s of entries in data frame.
+Generator for `CCDData`s of entries in data frame.
 """
-function images end
+function ccds end
 
-# generator for ImageHDU specified by data frame (i.e. path of file, hdu etc.)
-@resumable function images(df::DataFrame)
+# generator for CCDData specified by data frame (i.e. path of file, hdu etc.)
+@resumable function ccds(df::DataFrame)
     for row in eachrow(df)
-        @yield FITS(row.path)[row.hdu]
+        fh = FITS(row.path)
+        @yield CCDData(fh[row.hdu])
+        close(fh)
     end
 end

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -263,9 +263,7 @@ end
 Iterates over the `CCDData`s of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on `CCDData`s.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
-Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
-`ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
+The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Example
 ```julia
@@ -398,9 +396,7 @@ end
 Iterates over the image arrays of the collection applying function `f` at each step.
 
 It returns an array of output values of function `f` applied on image arrays.
-In addition to applying function `f`, the outputs can be saved. If `save = true`, it enables programmatical saving of returned value of the function `f` using [`CCDReduction.writefits`](@ref). File is saved at `path` specified by the user.
-Suffix and prefix can be added to filename of newly created files by modifying `save_suffix` and `save_prefix`, `save_delim` is used as delimiter.
-`ext` is the extension of files in collection, by default it is set to `r"fits(\\.tar\\.gz)?"i`.
+The output from `f` can be saved using the appropriate keyword arguments. The `save_prefix` argument will add a prefix to each filename delimited by `save_delim`. `save_suffix` will add a suffix prior to the extension, which can be manually provided via `ext`, similar to [`fitscollection`](@ref). Files will be saved in the directory they are stored unless `path` is given. Finally, `save` will default to `true` if any of the previous arguments are set, but can be manually overridden (useful for testing). Files will be saved using [`CCDReduction.writefits`](@ref).
 
 # Examples
 ```julia

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -40,6 +40,23 @@ function parse_name_ext(filename, ext)
     return filename[1:breaking_index - 1], filename[breaking_index:end]
 end
 
+
+"""
+    write_data(file_path, data)
+
+Writes `data` in FITS format at `file_path`.
+
+`FITSIO` takes over memory write in by `cfitsio`, which writes in row-major form, whereas when Julia gives that memory, it is assumed as column major.
+Therefore all data written by [`FITSIO.write`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#Base.write-Tuple{FITS,Dict{String,V}%20where%20V}) is transposed. This function allows the user to write the data in a consistent way to FITS file by transposing before writing.
+"""
+function write_data(file_path, data)
+    d = ndims(data)
+    transposed_data = permutedims(data, d:-1:1)
+    FITS(file_path, "w") do fh
+        write(fh, transposed_data)
+    end
+end
+
 #---------------------------------------------------------------------------------------
 @doc raw"""
     fitscollection(dir; recursive=true, abspath=true, keepext=true, ext=r"fits(\.tar\.gz)?", exclude=nothing, exclude_dir=nothing, exclude_key = ("", "HISTORY"))

--- a/src/collection.jl
+++ b/src/collection.jl
@@ -9,6 +9,37 @@ end
 
 parse_name(filename, ext, ::Val{true}) = filename
 
+# utility function for generating filename
+function generate_filename(path, save_location, save_prefix, save_suffix, save_delim, ext)
+    # get the filename
+    filename = last(splitdir(path))
+
+    # splitting name and extension
+    modified_name, extension = parse_name_ext(filename, "." * ext)
+
+    # adding prefix and suffix with delimiter
+    if !isnothing(save_prefix)
+        modified_name = string(save_prefix, save_delim, modified_name)
+    end
+    if !isnothing(save_suffix)
+        modified_name = string(modified_name, save_delim, save_suffix)
+    end
+
+    # adding extension to modified_name
+    file_path = joinpath(save_location, modified_name * extension)
+    return file_path
+end
+
+
+# utility function to return filename and extension separately
+# returns extension including "." at the beginning
+function parse_name_ext(filename, ext)
+    idxs = findall(ext, filename)
+    length(idxs) == 0 && return (filename, "")
+    breaking_index = first(last(idxs))
+    return filename[1:breaking_index - 1], filename[breaking_index:end]
+end
+
 #---------------------------------------------------------------------------------------
 @doc raw"""
     fitscollection(dir; recursive=true, abspath=true, keepext=true, ext=r"fits(\.tar\.gz)?", exclude=nothing, exclude_dir=nothing, exclude_key = ("", "HISTORY"))

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -1,11 +1,13 @@
 # helper functions
 
-#=
-FITSIO.jl takes over memory read in by cfitsio, which reads in row-major form,
-whereas when Julia takes that memory, it is assumed as column major.
-Therefore all data read by `read` is transposed.
-Related comment: https://github.com/JuliaAstro/CCDReduction.jl/pull/16#issuecomment-638492572
-=#
+"""
+    getdata(::FITSIO.ImageHDU)
+
+Loads image array form `ImageHDU`
+
+FITSIO.jl takes over memory read in by cfitsio, which reads in row-major form, whereas when Julia takes that memory, it is assumed as column major.
+Therefore all data read by [`FITSIO.read`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#Base.read-Tuple{ImageHDU}) is transposed. This function allows the user to read data in a consistent way to `Array` by transposing after reading.
+"""
 function getdata(hdu::ImageHDU)
     data = read(hdu)
     d = ndims(data)

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -38,9 +38,9 @@ end
 
 # separate function for combine involving CCDData because of custom header copying
 function combine(frames::Vararg{<:CCDData{<:Number}}; header_hdu = 1, kwargs...)
-    data_arrays = map(frame -> frame.data, frames)
+    data_arrays = map(frame -> data(frame), frames)
     processed_frame = combine(data_arrays...; kwargs...)
-    return CCDData(processed_frame, deepcopy(frames[header_hdu].hdr))
+    return CCDData(processed_frame, deepcopy(hdr(frames[header_hdu])))
 end
 
 # String supporting version of combine

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -1,9 +1,9 @@
 # helper functions
 
 """
-    getdata(::FITSIO.ImageHDU)
+    CCDReduction.getdata(::FITSIO.ImageHDU)
 
-Loads image array form `ImageHDU`
+Loads the given HDU as an `Array`, permuting the dimensions appropriately.
 
 FITSIO.jl takes over memory read in by cfitsio, which reads in row-major form, whereas when Julia takes that memory, it is assumed as column major.
 Therefore all data read by [`FITSIO.read`](http://juliaastro.github.io/FITSIO.jl/latest/api.html#Base.read-Tuple{ImageHDU}) is transposed. This function allows the user to read data in a consistent way to `Array` by transposing after reading.

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -121,6 +121,40 @@ end
     rm.(collection1[:, :path])
 end
 
+@testset "saving-filename" begin
+    dir = joinpath(@__DIR__, "data")
+    savedir = @__DIR__
+    collection = fitscollection(dir)
+
+    final = filenames(collection; save = true, path = savedir, save_prefix = "test1", save_suffix = "test2") do img
+        getdata(FITS(img)[1])
+    end
+
+    # testing function outputs
+    @test final[1] == getdata(M35070V[1])
+    @test final[2] == getdata(M6707HH[1])
+
+    collection1 = fitscollection(savedir; recursive = false)
+
+    # generating arrays from collection1
+    new_saved_data = map(eachrow(collection1)) do row
+        fh = FITS(row.path)
+        data = getdata(fh[row.hdu])
+        close(fh)
+        data
+    end
+
+    # testing saved data
+    @test final == new_saved_data
+
+    # testing saved filenames
+    @test collection1[1, :name] == "test1_M35070V_test2.fits"
+    @test collection1[2, :name] == "test1_M6707HH_test2.fits"
+
+    # removing data generated during testing
+    rm.(collection1[:, :path])
+end
+
 @testset "helper" begin
     # testing parse_name
     @test parse_name("abc.fits", "."*"fits", Val(true)) == "abc.fits"

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -116,6 +116,9 @@ end
     # testing saved filenames
     @test collection1[1, :name] == "test1_M35070V_test2.fits"
     @test collection1[2, :name] == "test1_M6707HH_test2.fits"
+
+    # remove the files generated during tests
+    rm.(collection1[:, :path])
 end
 
 @testset "helper" begin

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -1,7 +1,7 @@
 using CCDReduction: parse_name,
                     generate_filename,
                     parse_name_ext,
-                    write_data
+                    writefits
 
 @testset "fitscollection" begin
     # setting initial data
@@ -212,10 +212,10 @@ end
     parse_name_ext("abcd.fits", "." * "fits") == ("abcd", ".fits")
     parse_name_ext("11.12.20_HD106754.Fits.Tar.gz", "." * r"fits(\.tar\.gz)?"i) == ("11.12.20_HD106754", ".Fits.Tar.gz")
 
-    # testing write_data
+    # testing writefits
     filename = joinpath(@__DIR__, "test.fits")
     sample_data = rand(5, 10)
-    write_data(filename, sample_data)
+    writefits(filename, sample_data)
     fh = FITS(filename)
     image_array = getdata(fh[1])
     @test image_array == sample_data
@@ -224,7 +224,7 @@ end
 
     # writitng CCDData
     ccd = CCDData(zeros(4, 4))
-    write_data(filename, ccd)
+    writefits(filename, ccd)
     fh = FITS(filename)
     image_array = getdata(fh[1])
     @test image_array == ccd.data

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -83,9 +83,25 @@ end
 end
 
 @testset "helper" begin
+    # testing parse_name
     @test parse_name("abc.fits", "."*"fits", Val(true)) == "abc.fits"
     @test parse_name("abc.fits.tar.gz", "."*"fits.tar.gz", Val(false)) == "abc"
     @test parse_name("foo.fits.fits", "."*"fits", Val(false)) == "foo.fits"
     @test parse_name("foo.fits.fits", "."*r"fits(\.tar\.gz)?"i, Val(false)) == "foo.fits"
     @test parse_name("foo.fits", "."*r"fits(\.tar\.gz)?"i, Val(false)) == "foo"
+
+    # testing generate_filename
+    @test generate_filename("home/abcd.fits", @__DIR__, "test1", "test2", "_", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "test1_abcd_test2.fits")
+    @test generate_filename("home/tek/abcd.fits", @__DIR__, nothing, "test2", "_", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "abcd_test2.fits")
+    @test generate_filename("home/downloads/abcd.fits", @__DIR__, "test1", nothing, "_", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "test1_abcd.fits")
+    @test generate_filename("home/hello/abcd.fits", @__DIR__, nothing, nothing, "_", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "abcd.fits")
+    @test generate_filename("~/.julia/abcd.fits", @__DIR__, "test1", nothing, "__", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "test1__abcd.fits")
+    @test generate_filename("~/.julia/abcd.abcd", @__DIR__, "test1", nothing, "__", r"fits(\.tar\.gz)?"i) == joinpath(@__DIR__, "test1__abcd.abcd") # case when extension does not match
+
+    # testing parse_filename_ext
+    parse_name_ext("11.12.20_HD106754.fits.tar.gz", "." * r"fits(\.tar\.gz)?"i) == ("11.12.20_HD106754", ".fits.tar.gz")
+    parse_name_ext("abcd", "." * r"fits(\.tar\.gz)?"i) ==  ("abcd", "")
+    parse_name_ext("11.12.20_HD106754.fits", "." * "fits") == ("11.12.20_HD106754", ".fits")
+    parse_name_ext("abcd.fits", "." * "fits") == ("abcd", ".fits")
+    parse_name_ext("11.12.20_HD106754.Fits.Tar.gz", "." * r"fits(\.tar\.gz)?"i) == ("11.12.20_HD106754", ".Fits.Tar.gz")
 end

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -70,7 +70,7 @@ end
     @test arr1 == arr2
 end
 
-@testset "image-generators" begin
+@testset "ccds-generators" begin
     # setting initial data
     dir = joinpath(@__DIR__, "data")
     df = fitscollection(dir)
@@ -85,7 +85,7 @@ end
     end
 end
 
-@testset "saving-image" begin
+@testset "saving-ccds" begin
     dir = joinpath(@__DIR__, "data")
     savedir = @__DIR__
     collection = fitscollection(dir)
@@ -119,6 +119,17 @@ end
 
     # remove the files generated during tests
     rm.(collection1[:, :path])
+
+    # testing save functionality with path = nothing, i.e. at same location as of the input file
+    new_saved_data = ccds(collection; save_prefix = "save_without_path") do data
+        data
+    end
+    collection2 = fitscollection(dir)
+    @test first(size(collection2)) == 4
+
+    # removing data generated during testion
+    rm.(joinpath(dir, "save_without_path_M6707HH.fits"))
+    rm.(joinpath(dir, "save_without_path_M35070V.fits"))
 end
 
 @testset "saving-filename" begin
@@ -153,6 +164,17 @@ end
 
     # removing data generated during testing
     rm.(collection1[:, :path])
+
+    # testing save functionality with path = nothing, i.e. at same location as of the input file
+    new_saved_data = filenames(collection; save_prefix = "save_without_path") do filename
+        CCDData(filename)
+    end
+    collection2 = fitscollection(dir)
+    @test first(size(collection2)) == 4
+
+    # removing data generated during testion
+    rm.(joinpath(dir, "save_without_path_M6707HH.fits"))
+    rm.(joinpath(dir, "save_without_path_M35070V.fits"))
 end
 
 @testset "saving-arrays" begin
@@ -187,6 +209,17 @@ end
 
     # removing data generated during testing
     rm.(collection1[:, :path])
+
+    # testing save functionality with path = nothing, i.e. at same location as of the input file
+    new_saved_data = arrays(collection; save_prefix = "save_without_path") do data
+        data
+    end
+    collection2 = fitscollection(dir)
+    @test first(size(collection2)) == 4
+
+    # removing data generated during testion
+    rm.(joinpath(dir, "save_without_path_M6707HH.fits"))
+    rm.(joinpath(dir, "save_without_path_M35070V.fits"))
 end
 
 @testset "helper" begin

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -71,19 +71,14 @@ end
     # setting initial data
     dir = joinpath(@__DIR__, "data")
     df = fitscollection(dir)
-    arr1 = images(df) |> collect
+    arr1 = ccds(df) |> collect
     arr2 = map(eachrow(df)) do row
-        FITS(row.path)[row.hdu]
+        CCDData(FITS(row.path)[row.hdu])
     end
 
     for (hdu1, hdu2) in zip(arr1, arr2)
-        @test getdata(hdu1) == getdata(hdu2)
-        header1 = read_header(hdu1)
-        header2 = read_header(hdu2)
-        @test keys(header1) == keys(header2)
-        for (k1, k2) in zip(keys(header1), keys(header2))
-            @test header1[k1] == header2[k2]
-        end
+        @test hdu1.data == hdu2.data
+        test_header(hdu1, hdu2)
     end
 end
 

--- a/test/collection.jl
+++ b/test/collection.jl
@@ -1,4 +1,7 @@
-using CCDReduction: parse_name
+using CCDReduction: parse_name,
+                    generate_filename,
+                    parse_name_ext,
+                    write_data
 
 @testset "fitscollection" begin
     # setting initial data
@@ -104,4 +107,14 @@ end
     parse_name_ext("11.12.20_HD106754.fits", "." * "fits") == ("11.12.20_HD106754", ".fits")
     parse_name_ext("abcd.fits", "." * "fits") == ("abcd", ".fits")
     parse_name_ext("11.12.20_HD106754.Fits.Tar.gz", "." * r"fits(\.tar\.gz)?"i) == ("11.12.20_HD106754", ".Fits.Tar.gz")
+
+    # testing write_data
+    filename = joinpath(@__DIR__, "test.fits")
+    sample_data = rand(5, 10)
+    write_data(filename, sample_data)
+    fh = FITS(filename)
+    image_array = getdata(fh[1])
+    @test image_array == sample_data
+    close(fh) # closing handle so that generated file can be deleted
+    rm(filename) # remove the data generated during testing
 end


### PR DESCRIPTION
This PR will mostly be taken from #30 with some minor modifications.