### PR TITLE
fix NamedTuple key bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DataFrames = "0.21, 0.22"
+DataFrames = "0.21, 0.22, 1"
 FITSIO = "0.16.2"
 LazyStack = "0.0.7"
-ResumableFunctions = "0.5.1"
+ResumableFunctions = "0.5.1, 0.6"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -16,9 +16,3 @@ FITSIO = "0.16.2"
 LazyStack = "0.0.7"
 ResumableFunctions = "0.5.1"
 julia = "1.3"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,6 @@ FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 Underscores = "d9a01c3f-67ce-4d8c-9b55-35f6e4050bb1"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"
 FITSIO = "0.16.2"
 Underscores = "2"

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -46,7 +46,7 @@ julia> frame = [1.0 2.2 3.3 4.5];
 julia> bias = [0.0 0.2 0.3 0.5];
 
 julia> subtract_bias(frame, bias)
-1×4 Array{Float64,2}:
+1×4 Matrix{Float64}:
  1.0  2.0  3.0  4.0
 
 ```
@@ -90,11 +90,11 @@ If `frame` is a string, it will be loaded into [`CCDData`](@ref) first. The HDU 
 julia> frame = [4.0 2.0 3.0 1.0 1.0];
 
 julia> subtract_overscan(frame, (:, 4:5), dims = 2)
-1×5 Array{Float64,2}:
+1×5 Matrix{Float64}:
  3.0  1.0  2.0  0.0  0.0
 
 julia> subtract_overscan(frame, "[4:5, 1:1]", dims = 2)
-1×5 Array{Float64,2}:
+1×5 Matrix{Float64}:
  3.0  1.0  2.0  0.0  0.0
 
 ```
@@ -140,13 +140,13 @@ julia> frame = ones(3, 3);
 julia> flat = fill(2.0, (3, 3));
 
 julia> flat_correct(frame, flat, norm_value = 1.0)
-3×3 Array{Float64,2}:
+3×3 Matrix{Float64}:
  0.5  0.5  0.5
  0.5  0.5  0.5
  0.5  0.5  0.5
 
 julia> flat_correct(frame, flat)
-3×3 Array{Float64,2}:
+3×3 Matrix{Float64}:
  1.0  1.0  1.0
  1.0  1.0  1.0
  1.0  1.0  1.0
@@ -178,7 +178,7 @@ If `frame` is a string, it will be loaded into [`CCDData`](@ref) first. The HDU 
 julia> frame = ones(5, 5);
 
 julia> trim(frame, (:, 2:5))
-5×1 Array{Float64,2}:
+5×1 Matrix{Float64}:
  1.0
  1.0
  1.0
@@ -186,7 +186,7 @@ julia> trim(frame, (:, 2:5))
  1.0
 
 julia> trim(frame, "[2:5, 1:5]")
-5×1 Array{Float64,2}:
+5×1 Matrix{Float64}:
  1.0
  1.0
  1.0
@@ -255,13 +255,13 @@ If `frame` is a string, it will be loaded into [`CCDData`](@ref) first. The HDU 
 julia> frame = reshape(1:25, (5, 5));
 
 julia> crop(frame, (3, 3))
-3×3 Array{Int64,2}:
+3×3 Matrix{Int64}:
  7  12  17
  8  13  18
  9  14  19
 
 julia> crop(frame, (4, 3), force_equal = false)
-4×3 Array{Int64,2}:
+4×3 Matrix{Int64}:
  6  11  16
  7  12  17
  8  13  18
@@ -331,12 +331,12 @@ Header of output file (if applicable) is specified by `header_hdu` which by defa
 julia> frame = [reshape(1.0:4.0, (2, 2)) for i = 1:4];
 
 julia> combine(frame)
-2×2 Array{Float64,2}:
+2×2 Matrix{Float64}:
  1.0  3.0
  2.0  4.0
 
 julia> combine(frame, method = sum)
-2×2 Array{Float64,2}:
+2×2 Matrix{Float64}:
  4.0  12.0
  8.0  16.0
 
@@ -381,13 +381,13 @@ julia> frame = ones(3, 3);
 julia> dark_frame = ones(3, 3);
 
 julia> subtract_dark(frame, dark_frame)
-3×3 Array{Float64,2}:
+3×3 Matrix{Float64}:
  0.0  0.0  0.0
  0.0  0.0  0.0
  0.0  0.0  0.0
 
 julia> subtract_dark(frame, dark_frame, data_exposure = 1, dark_exposure = 4)
-3×3 Array{Float64,2}:
+3×3 Matrix{Float64}:
  0.75  0.75  0.75
  0.75  0.75  0.75
  0.75  0.75  0.75

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
+FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fits.jl
+++ b/test/fits.jl
@@ -1,14 +1,5 @@
 using CCDReduction: getdata
 
-function test_header(ccd1::CCDData, ccd2::CCDData)
-    header1 = ccd1.hdr
-    header2 = ccd2.hdr
-    @test keys(header1) == keys(header2)
-    for (k1, k2) in zip(keys(header1), keys(header2))
-        @test header1[k1] == header2[k2]
-    end
-end
-
 @testset "bias subtraction(FITS)" begin
     # setting initial data
     hdu_frame = CCDData(M6707HH[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,15 @@ using FITSIO
 
 include("data.jl")
 
-@testset "basic methods" begin
-    include("methods.jl")
+function test_header(ccd1::CCDData, ccd2::CCDData)
+    header1 = ccd1.hdr
+    header2 = ccd2.hdr
+    @test keys(header1) == keys(header2)
+    for (k1, k2) in zip(keys(header1), keys(header2))
+        @test header1[k1] == header2[k2]
+    end
 end
 
-@testset "FITS interface" begin
-    include("fits.jl")
-end
-
-@testset "collection" begin
-    include("collection.jl")
-end
+@testset "basic methods" begin include("methods.jl") end
+@testset "FITS interface" begin include("fits.jl") end
+@testset "collection" begin include("collection.jl") end


### PR DESCRIPTION
A previously unaddressed bug occurred where when multiple HDU header entries with the same keyword are parsed by `fitscollection` would fail due to new Julia errors. This update maintains the same behavior by manually finding the unique keys in the header and keeping the first one. In addition, I have tidied up some test code to use temp directories.
