### PR TITLE
Compat bump for ResumableFunctions and a versionbump for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CCDReduction"
 uuid = "b790e538-3052-4cb9-9f1f-e05859a455f5"
 authors = ["Siddharth Lal"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -14,6 +14,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 DataFrames = "0.21, 0.22, 1"
 FITSIO = "0.16, 0.17"
 LazyStack = "0.0.7"
-ResumableFunctions = "0.5.1, 0.6"
+ResumableFunctions = "0.5.1, 0.6, 1"
 Statistics = "1"
 julia = "1.3"


### PR DESCRIPTION
ResumableFunctions 1.0.0 was released, now with proper support for variable scopes (previously it was breaking local scopes). I tested it locally and it runs with CCDReduction.jl, so providing a version bump here.

CCDReduction.jl is also used in the CI of ResumableFunctions to check for unintentional breaking changes. Having a new release of CCDReduction.jl would be valuable for our CI.
