### PR TITLE
remove deprecated Vararg{<:...}

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -41,7 +41,7 @@ for func in (:crop, :trim, :subtract_overscan)
 end
 
 # separate function for combine involving CCDData because of custom header copying
-function combine(frames::Vararg{<:CCDData{<:Number}}; header_hdu = 1, kwargs...)
+function combine(frames::Vararg{CCDData{<:Number}}; header_hdu = 1, kwargs...)
     data_arrays = map(frame -> data(frame), frames)
     processed_frame = combine(data_arrays...; kwargs...)
     return CCDData(processed_frame, deepcopy(hdr(frames[header_hdu])))

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -356,7 +356,7 @@ julia> combine(frame, method = sum)
 
 ```
 """
-function combine(frames::Vararg{<:AbstractArray{<:Number}}; method = median)
+function combine(frames::Vararg{AbstractArray{<:Number}}; method = median)
     firstframe = first(frames)
     dim = ndims(firstframe) + 1
     shape = size(firstframe)


### PR DESCRIPTION
More vararg hunting. Caught during nightly testing for JuliaAstro site

Could we also tag a new release? Looks like it's been a minute